### PR TITLE
Db persistence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,6 @@ build:
 
 run: build
 	./$(APP_NAME)
+
+test:
+	go test ./...

--- a/internal/pull.go
+++ b/internal/pull.go
@@ -24,6 +24,7 @@ func pullHandler(cmd *cobra.Command, args []string) {
 
 	// Get the .dot-sync/files directory path
 	dotSyncFilesPath := filepath.Join(shared.FindHomeDir(), shared.GetDotSyncFilesDir())
+	dotSyncDir := filepath.Join(shared.FindHomeDir(), shared.GetDotSyncDir())
 
 	// Ensure the .dot-sync/files directory exists
 	if err := shared.EnsureDir(dotSyncFilesPath); err != nil {
@@ -40,7 +41,7 @@ func pullHandler(cmd *cobra.Command, args []string) {
 	}
 
 	// Pull from remote storage
-	if err := sp.PullFromStorage(dotSyncFilesPath); err != nil {
+	if err := sp.PullFromStorage(dotSyncDir); err != nil {
 		fmt.Println("Failed to pull from storage:", err)
 		return
 	}

--- a/internal/shared/utils.go
+++ b/internal/shared/utils.go
@@ -20,10 +20,6 @@ func GetDotSyncFilesDir() string {
 	return ".dot-sync/files"
 }
 
-func GetGitRemoteURL() string {
-	return "https://github.com/tylerkeyes/dot-sync-test.git"
-}
-
 type contextKey string
 
 func GetStorageProviderKey() contextKey {

--- a/internal/shared/utils_test.go
+++ b/internal/shared/utils_test.go
@@ -19,13 +19,6 @@ func TestGetDotSyncFilesDir(t *testing.T) {
 	}
 }
 
-func TestGetGitRemoteURL(t *testing.T) {
-	expected := "https://github.com/tylerkeyes/dot-sync-test.git"
-	if GetGitRemoteURL() != expected {
-		t.Errorf("expected %q, got %q", expected, GetGitRemoteURL())
-	}
-}
-
 func TestGetStorageProviderKey(t *testing.T) {
 	expected := contextKey("storageProvider")
 	if key := GetStorageProviderKey(); key != expected {

--- a/internal/storage/git_storage.go
+++ b/internal/storage/git_storage.go
@@ -16,7 +16,7 @@ type GitStorage struct {
 
 func (s *GitStorage) InitializeStorage() error {
 	home := shared.FindHomeDir()
-	dir := filepath.Join(home, shared.GetDotSyncFilesDir())
+	dir := filepath.Join(home, shared.GetDotSyncDir())
 
 	// Ensure the directory exists before running git commands
 	if err := shared.EnsureDir(dir); err != nil {

--- a/internal/storage/git_storage.go
+++ b/internal/storage/git_storage.go
@@ -17,10 +17,14 @@ type GitStorage struct {
 func (s *GitStorage) InitializeStorage() error {
 	home := shared.FindHomeDir()
 	dir := filepath.Join(home, shared.GetDotSyncDir())
+	filesDir := filepath.Join(home, shared.GetDotSyncFilesDir())
 
-	// Ensure the directory exists before running git commands
+	// Ensure both directories exist before running git commands
 	if err := shared.EnsureDir(dir); err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", dir, err)
+	}
+	if err := shared.EnsureDir(filesDir); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", filesDir, err)
 	}
 
 	// Initialize git repo if not already

--- a/internal/storage/git_storage_test.go
+++ b/internal/storage/git_storage_test.go
@@ -137,8 +137,9 @@ func TestGitStorage_InitializeStorage_Complete(t *testing.T) {
 		t.Error("expected .dot-sync/files directory to be created")
 	}
 
-	// Check git initialization
-	gitPath := filepath.Join(dotSyncFilesPath, ".git")
+	// Check git initialization - git repo is created in .dot-sync directory, not .dot-sync/files
+	dotSyncPath := filepath.Join(tempHome, ".dot-sync")
+	gitPath := filepath.Join(dotSyncPath, ".git")
 	if _, statErr := os.Stat(gitPath); os.IsNotExist(statErr) {
 		t.Log("git init may have failed, which is expected in test environment")
 	}
@@ -383,8 +384,9 @@ func TestGitStorage_InitializeStorage_DirectoryCreation(t *testing.T) {
 		t.Error("expected .dot-sync/files directory to be created")
 	}
 
-	// The git operations should also be attempted
-	gitPath := filepath.Join(dotSyncFilesPath, ".git")
+	// The git operations should also be attempted - git repo is created in .dot-sync directory, not .dot-sync/files
+	dotSyncPath := filepath.Join(tempHome, ".dot-sync")
+	gitPath := filepath.Join(dotSyncPath, ".git")
 	if _, err := os.Stat(gitPath); os.IsNotExist(err) {
 		// Git init might fail in test environment, that's ok
 		t.Log("git init may have failed, which is expected in test environment")

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -20,6 +20,7 @@ func NewSyncCmd() *cobra.Command {
 
 func syncHandler(cmd *cobra.Command, args []string) {
 	dotSyncFilesPath := filepath.Join(shared.FindHomeDir(), shared.GetDotSyncFilesDir())
+	dotSyncDir := filepath.Join(shared.FindHomeDir(), shared.GetDotSyncDir())
 
 	database, err := db.OpenDotSyncDB()
 	if err != nil {
@@ -42,7 +43,7 @@ func syncHandler(cmd *cobra.Command, args []string) {
 
 	ctx := cmd.Context()
 	sp := ctx.Value(shared.GetStorageProviderKey()).(storage.StorageProvider)
-	if err := sp.PushToStorage(dotSyncFilesPath); err != nil {
+	if err := sp.PushToStorage(dotSyncDir); err != nil {
 		fmt.Println("Failed to push to storage:", err)
 		return
 	}


### PR DESCRIPTION
Adding the DB to the persistence, as it is hard to sync files across systems when only one system knows where they should go.